### PR TITLE
Add text printer for showing results on tty

### DIFF
--- a/eqparsetables.py
+++ b/eqparsetables.py
@@ -6,6 +6,7 @@ import argparse
 import os
 import gpcastreader as gpc
 import enjincastprinter as ecp
+import textcastprinter as tcp
 import parsedb
 
 __author__ = 'Andrew Quinn'
@@ -32,6 +33,7 @@ def main(argv):
     parser.add_argument('-b', '--blacklist', help='path to blacklist', metavar='PATH')
     parser.add_argument('-c', '--config', help='path to config CSV file', metavar='PATH')
     parser.add_argument('--dps', action='store_true', help='force dps formatting')
+    parser.add_argument('--tty', action='store_true', help='output to tty (default to enjin post)')
     parser.add_argument('-f', '--dpsfirst', help='highest ranking dpser to show', metavar='FIRST')
     parser.add_argument('-l', '--dpslast', help='lowest ranking dpser to show', metavar='LAST')
 
@@ -52,11 +54,17 @@ def main(argv):
 
     if dps:
         reader = gpc.GPDPSReader(input_path, config_path)
-        ecp.print_dps_table(reader.mob, reader.time, reader.guild_stats, reader.dpser_dod, dps_first, dps_last)
+        if args.tty:
+            tcp.print_dps_table(reader, dps_first, dps_last)
+        else:
+            ecp.print_dps_table(reader, dps_first, dps_last)
     else:
         reader = gpc.GPCastReader(input_path, config_path, blacklist_path)
         pdb = parsedb.ParseDB(reader.get_spells_cast_by_class(), reader.classes, reader.caster_dod, reader.config)
-        ecp.print_cast_tables((pdb.get_cast_table(eq_class) for eq_class in sorted(reader.classes)))
+        if args.tty:
+            tcp.print_cast_tables((pdb.get_cast_table(eq_class) for eq_class in sorted(reader.classes)))
+        else:
+            ecp.print_cast_tables((pdb.get_cast_table(eq_class) for eq_class in sorted(reader.classes)))
 
 
 if __name__ == '__main__':

--- a/eqparsetables.py
+++ b/eqparsetables.py
@@ -33,7 +33,7 @@ def main(argv):
     parser.add_argument('-b', '--blacklist', help='path to blacklist', metavar='PATH')
     parser.add_argument('-c', '--config', help='path to config CSV file', metavar='PATH')
     parser.add_argument('--dps', action='store_true', help='force dps formatting')
-    parser.add_argument('--tty', action='store_true', help='output to tty (default to enjin post)')
+    parser.add_argument('--tty', action='store_true', help='output text (default is enjin post format)')
     parser.add_argument('-f', '--dpsfirst', help='highest ranking dpser to show', metavar='FIRST')
     parser.add_argument('-l', '--dpslast', help='lowest ranking dpser to show', metavar='LAST')
 

--- a/gpcastreader.py
+++ b/gpcastreader.py
@@ -103,12 +103,16 @@ class GPDPSReader:
 
         self.mob = 'unknown'
         self.time = 0
+        self.date = 'unknown'
 
         self.dpser_dod = self.init_dps()
 
+    def info(self):
+        return [ self.mob, self.time, self.date ]
+
     def init_dps(self):
         dpser = 'unknown'
-        gp_header = re.compile('(?P<mob>(?:Combined: )?(?:[\w`,]+ ?)+) on \d{1,2}/\d{1,2}/\d{2,4} in (?P<time>\d{1,5})sec')
+        gp_header = re.compile('(?P<mob>(?:Combined: )?(?:[\w`,]+ ?)+) on (?P<date>\d{1,2}/\d{1,2}/\d{2,4}) in (?P<time>\d{1,5})sec')
         name_grabber = re.compile('\[B\](?P<name>\w+)\[/B\]')
         dps_grabber = re.compile('(?P<total>\d+) \@ (?P<sdps>\d+) sdps \((?P<dps>\d+) dps in (?P<time>\d+)s\) \[(?P<pct>\d+(\.\d+)?)%\]')
         gp_bullet = ' --- '
@@ -148,6 +152,7 @@ class GPDPSReader:
         if m:
             self.mob = m.group('mob')
             self.time = int(m.group('time'))
+            self.date = m.group('date')
         elif n:
             dpser = n.group('name')
             try:

--- a/textcastprinter.py
+++ b/textcastprinter.py
@@ -3,14 +3,14 @@ import sys
 
 
 def print_cast_table(table: parsedb.CastTable):
-    print('[size=5][b]{0}[/b][/size]'.format(table.class_name))
-    print('[table]')
+    print('{0}'.format(table.class_name))
+    print('')
     print(make_header('', *table.get_players()))
     print(make_header('Total', *[str(x) for x in table.get_totals()]))
     spells = table.get_spells()
     for i, row in enumerate(table.get_rows()):
         print(make_row(spells[i], *[str(x) for x in row]))
-    print('[/table]')
+    print('')
 
 
 def print_cast_tables(tables: [parsedb.CastTable]):
@@ -29,10 +29,10 @@ def print_cast_tables(tables: [parsedb.CastTable]):
 def print_dps_table(fight_info, start=1, stop=sys.maxsize):
     stats = fight_info.guild_stats
     dpser_dod = fight_info.dpser_dod
-    print('[size=5][b]{0} in {1} seconds on {2}[/b][/size]'.format(*fight_info.info()))
-    print('[table]')
+    print('')
+    print('{0} in {1} seconds on {2}'.format(*fight_info.info()))
     print(make_header('', '', 'SDPS', 'Total DMG', 'Percentage'))
-    print(make_header('', 'Raid', humanize(stats['sdps']), humanize(stats['total']), stats['pct'] + '%'))
+    print(make_header('', '__Raid__', humanize(stats['sdps']), humanize(stats['total']), stats['pct'] + '%'))
     for rank, player in enumerate(sorted(dpser_dod.items(), key=lambda x: int(x[1]['sdps']), reverse=True)):
         if rank + 1 < start:
             continue
@@ -40,7 +40,7 @@ def print_dps_table(fight_info, start=1, stop=sys.maxsize):
             break
         print(make_row(str(rank + 1), player[0], humanize(player[1]['sdps']), humanize(player[1]['total']),
                        player[1]['pct'] + '%'))
-    print('[/table]')
+    print('')
 
 
 def make_header(*args):
@@ -50,9 +50,7 @@ def make_header(*args):
     :param args: the values to be formatted
     :return: a string corresponding to a row in enjin table format
     """
-    header = '[tr][td][b]{0}[/b][/td][/tr]'
-    header_sep = '[/b][/td][td][b]'
-    return header.format(header_sep.join(args))
+    return make_row(*args)
 
 
 def make_row(*args):
@@ -62,9 +60,8 @@ def make_row(*args):
     :param args: the values to be formatted
     :return: a string corresponding to a row in enjin table format
     """
-    row = '[tr][td]{0}[/td][/tr]'
-    row_sep = '[/td][td]'
-    return row.format(row_sep.join(args))
+    sys.stdout.write("%2s %20s %15s %10s   %4s" % (args))
+    return ""
 
 
 def humanize(s):


### PR DESCRIPTION
- Added a text printer, to see the results (nicely) on tty.
  - We may want to refactor them so they're more DRY, but for now it suffices.
  - (And my python fu isn't up to the task yet)
- Added the date of the event into the header - useful batch processing or results-for-week, rather than per-day.
- Instead of passing each argument into the printer, just pass the object and let the reader query each item.
  - This seemed easier than adding yet another argument and the list was getting long, but I'm not opposed to keeping each as individual argument.
